### PR TITLE
Bugfix: Incorrect byte offsets w/ multiple delta updates

### DIFF
--- a/src/ArrayParser.re
+++ b/src/ArrayParser.re
@@ -88,9 +88,9 @@ let parse = (parser: Parser.t, delta: option(Delta.t), lines: array(string)) => 
   let byteOffsets: array(int) = Array.make(len, 0);
 
   // The interop between C <-> OCaml is expensive for large files.
-  // We should look to see if we can instead access the array directly 
+  // We should look to see if we can instead access the array directly
   // from the C side.
-  let f = (_byteOffset, line, col) => {
+  let f = (_byteOffset, line, col) =>
     if (line < len) {
       let v = lines[line] ++ "\n";
       let strlen = String.length(v);
@@ -104,15 +104,14 @@ let parse = (parser: Parser.t, delta: option(Delta.t), lines: array(string)) => 
     } else {
       None;
     };
-  };
-  
+
   // TODO: Copy over byte offsets from previous baseline / delta
   let i = ref(0);
   while (i^ < len) {
     let idx = i^;
     byteOffsets[idx] = String.length(lines[idx]) + 1;
     incr(i);
-  }
+  };
 
   let oldTree =
     switch (delta) {

--- a/src/ArrayParser.re
+++ b/src/ArrayParser.re
@@ -16,7 +16,13 @@ module Baseline = {
 };
 
 module Delta = {
-  type t = {tree: Tree.t};
+  type t = {
+    tree: Tree.t,
+    startLine: int,
+    oldEndLine: int,
+    oldOffsets: array(int),
+    newLines: array(string),
+  };
 
   let getOffsetToLine = (startLine, endLine, lines: array(int)) => {
     let i = ref(startLine);
@@ -68,7 +74,11 @@ module Delta = {
         newEndLine,
       );
     {
-      tree: newTree
+      tree: newTree,
+      startLine,
+      oldEndLine,
+      newLines,
+      oldOffsets: baseline.lengths,
     };
   };
 };
@@ -77,11 +87,13 @@ let parse = (parser: Parser.t, delta: option(Delta.t), lines: array(string)) => 
   let len = Array.length(lines);
   let byteOffsets: array(int) = Array.make(len, 0);
 
-  let f = (_byteOffset, line, col) =>
+  // The interop between C <-> OCaml is expensive for large files.
+  // We should look to see if we can instead access the array directly 
+  // from the C side.
+  let f = (_byteOffset, line, col) => {
     if (line < len) {
       let v = lines[line] ++ "\n";
       let strlen = String.length(v);
-      byteOffsets[line] = strlen;
 
       if (col < strlen) {
         let ret = String.sub(v, col, strlen - col);
@@ -92,10 +104,19 @@ let parse = (parser: Parser.t, delta: option(Delta.t), lines: array(string)) => 
     } else {
       None;
     };
+  };
+  
+  // TODO: Copy over byte offsets from previous baseline / delta
+  let i = ref(0);
+  while (i^ < len) {
+    let idx = i^;
+    byteOffsets[idx] = String.length(lines[idx]) + 1;
+    incr(i);
+  }
 
   let oldTree =
     switch (delta) {
-    | Some({tree}) => Some(tree)
+    | Some({tree, _}) => Some(tree)
     | None => None
     };
 

--- a/src/ArrayParser.re
+++ b/src/ArrayParser.re
@@ -67,7 +67,9 @@ module Delta = {
         oldEndLine,
         newEndLine,
       );
-    {tree: newTree};
+    {
+      tree: newTree
+    };
   };
 };
 

--- a/src/Syntax.re
+++ b/src/Syntax.re
@@ -55,7 +55,7 @@ module Token = {
   };
 
   let getPosition = (v: t) => {
-    let (p,_, _, _) = v;
+    let (p, _, _, _) = v;
     p;
   };
 
@@ -78,7 +78,15 @@ module Token = {
     let (p, e, scopes, tok) = v;
     let stringScopes = List.map(_showScope, scopes);
     let scopes = String.concat(".", stringScopes);
-    "Token(" ++ Position.show(p) ++ " - " ++ Position.show(e) ++ ":" ++ scopes ++ "|" ++ tok ++ ")";
+    "Token("
+    ++ Position.show(p)
+    ++ " - "
+    ++ Position.show(e)
+    ++ ":"
+    ++ scopes
+    ++ "|"
+    ++ tok
+    ++ ")";
   };
 };
 
@@ -118,21 +126,29 @@ let createArrayTokenNameResolver = (v: array(string), range: Range.t) =>
     if (len == 0 || range.startPosition.column == range.endPosition.column) {
       "";
     } else {
-      switch(
-      "\""
-      ++ String.sub(
-           line,
-           range.startPosition.column,
-           range.endPosition.column - range.startPosition.column,
-         )
-      ++ "\"") {
-      | exception exn => 
-      print_endline ("Syntax: ");
-      print_endline (" -line: " ++string_of_int(range.startPosition.line) ++ " col: " ++ string_of_int(range.startPosition.column) ++ " endCol: " ++ string_of_int(range.endPosition.column));
-      print_endline (" -str: " ++ line);
-      raise(exn)
+      switch (
+        "\""
+        ++ String.sub(
+             line,
+             range.startPosition.column,
+             range.endPosition.column - range.startPosition.column,
+           )
+        ++ "\""
+      ) {
+      | exception exn =>
+        print_endline("Syntax: ");
+        print_endline(
+          " -line: "
+          ++ string_of_int(range.startPosition.line)
+          ++ " col: "
+          ++ string_of_int(range.startPosition.column)
+          ++ " endCol: "
+          ++ string_of_int(range.endPosition.column),
+        );
+        print_endline(" -str: " ++ line);
+        raise(exn);
       | v => v
-      }
+      };
     };
   };
 

--- a/src/Syntax.re
+++ b/src/Syntax.re
@@ -126,7 +126,6 @@ let createArrayTokenNameResolver = (v: array(string), range: Range.t) =>
     if (len == 0 || range.startPosition.column == range.endPosition.column) {
       "";
     } else {
-      switch (
         "\""
         ++ String.sub(
              line,
@@ -134,21 +133,6 @@ let createArrayTokenNameResolver = (v: array(string), range: Range.t) =>
              range.endPosition.column - range.startPosition.column,
            )
         ++ "\""
-      ) {
-      | exception exn =>
-        print_endline("Syntax: ");
-        print_endline(
-          " -line: "
-          ++ string_of_int(range.startPosition.line)
-          ++ " col: "
-          ++ string_of_int(range.startPosition.column)
-          ++ " endCol: "
-          ++ string_of_int(range.endPosition.column),
-        );
-        print_endline(" -str: " ++ line);
-        raise(exn);
-      | v => v
-      };
     };
   };
 

--- a/src/Syntax.re
+++ b/src/Syntax.re
@@ -126,13 +126,13 @@ let createArrayTokenNameResolver = (v: array(string), range: Range.t) =>
     if (len == 0 || range.startPosition.column == range.endPosition.column) {
       "";
     } else {
-        "\""
-        ++ String.sub(
-             line,
-             range.startPosition.column,
-             range.endPosition.column - range.startPosition.column,
-           )
-        ++ "\""
+      "\""
+      ++ String.sub(
+           line,
+           range.startPosition.column,
+           range.endPosition.column - range.startPosition.column,
+         )
+      ++ "\"";
     };
   };
 

--- a/src/Syntax.re
+++ b/src/Syntax.re
@@ -36,7 +36,7 @@ let getErrorRanges = (node: Node.t) => {
 type scope = (int, string);
 
 module Token = {
-  type t = (Position.t, list(scope), string);
+  type t = (Position.t, Position.t, list(scope), string);
 
   let ofNode = (~getTokenName, scopes, node: Node.t) => {
     let isNamed = Node.isNamed(node);
@@ -46,17 +46,27 @@ module Token = {
     let tokenName = getTokenName(range);
 
     switch (isNamed) {
-    | false => (position, scopes, tokenName)
+    | false => (position, endPosition, scopes, tokenName)
     | true =>
       let nodeType = Node.getType(node);
       let scopes = [(0, nodeType), ...scopes];
-      (position, scopes, tokenName);
+      (position, endPosition, scopes, tokenName);
     };
   };
 
   let getPosition = (v: t) => {
-    let (p, _, _) = v;
+    let (p,_, _, _) = v;
     p;
+  };
+
+  let getEndPosition = (v: t) => {
+    let (_, e, _, _) = v;
+    e;
+  };
+
+  let getName = (v: t) => {
+    let (_, _, _, n) = v;
+    n;
   };
 
   let _showScope = (scope: scope) => {
@@ -65,10 +75,10 @@ module Token = {
   };
 
   let show = (v: t) => {
-    let (p, scopes, tok) = v;
+    let (p, e, scopes, tok) = v;
     let stringScopes = List.map(_showScope, scopes);
     let scopes = String.concat(".", stringScopes);
-    "Token(" ++ Position.show(p) ++ ":" ++ scopes ++ "|" ++ tok ++ ")";
+    "Token(" ++ Position.show(p) ++ " - " ++ Position.show(e) ++ ":" ++ scopes ++ "|" ++ tok ++ ")";
   };
 };
 
@@ -108,13 +118,21 @@ let createArrayTokenNameResolver = (v: array(string), range: Range.t) =>
     if (len == 0 || range.startPosition.column == range.endPosition.column) {
       "";
     } else {
+      switch(
       "\""
       ++ String.sub(
            line,
            range.startPosition.column,
            range.endPosition.column - range.startPosition.column,
          )
-      ++ "\"";
+      ++ "\"") {
+      | exception exn => 
+      print_endline ("Syntax: ");
+      print_endline (" -line: " ++string_of_int(range.startPosition.line) ++ " col: " ++ string_of_int(range.startPosition.column) ++ " endCol: " ++ string_of_int(range.endPosition.column));
+      print_endline (" -str: " ++ line);
+      raise(exn)
+      | v => v
+      }
     };
   };
 

--- a/src/Types.re
+++ b/src/Types.re
@@ -28,6 +28,20 @@ module Range = {
     endPosition,
   };
 
+  let createi = (
+    ~startLine,
+    ~startColumn,
+    ~endLine,
+    ~endColumn,
+    ()
+  ) => {
+    create(
+    ~startPosition=Position.create(~line=startLine, ~column=startColumn, ()),
+    ~endPosition=Position.create(~line=endLine, ~column=endColumn, ()),
+    ()
+    );
+  };
+
   let isInRange = (range: t, position: Position.t) => {
     (
       position.line == range.startPosition.line

--- a/src/Types.re
+++ b/src/Types.re
@@ -28,17 +28,12 @@ module Range = {
     endPosition,
   };
 
-  let createi = (
-    ~startLine,
-    ~startColumn,
-    ~endLine,
-    ~endColumn,
-    ()
-  ) => {
+  let createi = (~startLine, ~startColumn, ~endLine, ~endColumn, ()) => {
     create(
-    ~startPosition=Position.create(~line=startLine, ~column=startColumn, ()),
-    ~endPosition=Position.create(~line=endLine, ~column=endColumn, ()),
-    ()
+      ~startPosition=
+        Position.create(~line=startLine, ~column=startColumn, ()),
+      ~endPosition=Position.create(~line=endLine, ~column=endColumn, ()),
+      (),
     );
   };
 

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -193,6 +193,17 @@ CAMLprim value rets_tree_edit_native(value vTree, value vStartByte,
   edit.new_end_point.row = Long_val(vNewEndLine);
   edit.new_end_point.column = 0;
 
+  /*printf("SENDING EDIT:\n start_byte: %ld\n old_end_byte: %ld\n new_end_byte: %ld\n, start_row: %ld\n start_col: %ld\n old_end_row: %ld\n old_end_col: %ld\n new_end_row: %ld\n new_end_col: %ld\n",
+    edit.start_byte,
+    edit.old_end_byte,
+    edit.new_end_byte,
+    edit.start_point.row,
+    edit.start_point.column,
+    edit.old_end_point.row,
+    edit.old_end_point.column,
+    edit.new_end_point.row,
+    edit.new_end_point.column);*/
+    
   TSTree *ret = ts_tree_copy(tree);
 
   ts_tree_edit(ret, &edit);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -193,8 +193,9 @@ CAMLprim value rets_tree_edit_native(value vTree, value vStartByte,
   edit.new_end_point.row = Long_val(vNewEndLine);
   edit.new_end_point.column = 0;
 
-  /*printf("SENDING EDIT:\n start_byte: %ld\n old_end_byte: %ld\n new_end_byte: %ld\n, start_row: %ld\n start_col: %ld\n old_end_row: %ld\n old_end_col: %ld\n new_end_row: %ld\n new_end_col: %ld\n",
-    edit.start_byte,
+  /*printf("SENDING EDIT:\n start_byte: %ld\n old_end_byte: %ld\n new_end_byte:
+    %ld\n, start_row: %ld\n start_col: %ld\n old_end_row: %ld\n old_end_col:
+    %ld\n new_end_row: %ld\n new_end_col: %ld\n", edit.start_byte,
     edit.old_end_byte,
     edit.new_end_byte,
     edit.start_point.row,
@@ -203,7 +204,7 @@ CAMLprim value rets_tree_edit_native(value vTree, value vStartByte,
     edit.old_end_point.column,
     edit.new_end_point.row,
     edit.new_end_point.column);*/
-    
+
   TSTree *ret = ts_tree_copy(tree);
 
   ts_tree_edit(ret, &edit);

--- a/test/ArrayParserTest.re
+++ b/test/ArrayParserTest.re
@@ -258,5 +258,74 @@ describe("ArrayParser", ({describe, _}) => {
       expect.string(Syntax.Token.getName(rightBracket)).toEqual("\"]\"");
       List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
     });
+    test("regression test: multiple delta updates", ({expect, _}) => {
+      let jsonParser = Parser.json();
+      let start = [|"[", "]"|];
+      let (_, baseline) = ArrayParser.parse(jsonParser, None, start);
+
+      let delta1 = [|"\"a\",", "\"b\","|];
+      let end1 = [|"[", "\"a\",", "\"b\",", "]"|];
+
+      let delta = ArrayParser.Delta.create(baseline, 1, 1, delta1);
+      let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end1);
+
+      let delta2 = [|""|];
+      let end2 = [|"[", "\"a\",", "\"b\",", "", "]"|];
+      
+      let delta = ArrayParser.Delta.create(baseline, 3, 3, delta2);
+      let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end2);
+
+      let delta3 = [|"\""|];
+      let end3 = [|"[", "\"a\",", "\"b\",", "\"", "]"|];
+
+      let delta = ArrayParser.Delta.create(baseline, 3, 4, delta3);
+      let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), end3);
+
+      /*let delta4 = [|"\"c"|];
+      let end4 = [|"[", "\"abc\",", "\"c", "]"|];
+      
+      let delta = ArrayParser.Delta.create(baseline, 2, 3, delta4);
+      let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end4);
+
+      let delta5 = [|"\"\",", "\"d"|];
+      let end5 = [|"[", "\"abc\",", "\"\",", "\"d", "]"|];
+
+      let delta = ArrayParser.Delta.create(baseline, 2, 3, delta5);
+      let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end5);
+      
+      let delta6 = [|"e"|];
+      let end6 = [|"[", "\"abc\",", "\"\",", "\"d", "e", "]"|];
+
+      let delta = ArrayParser.Delta.create(baseline, 3, 3, delta6);
+      let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), end6); */
+      
+      let node = Tree.getRootNode(tree);
+      let rangeLine2 = Types.Range.create(
+        ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
+        ~endPosition=Types.Position.create(~line=6, ~column=0, ()),
+        (),
+      );
+
+      let getTokenName = Syntax.createArrayTokenNameResolver(end3);
+      let tokens = Syntax.getTokens(~getTokenName, ~range=rangeLine2, node);
+      // There should be these tokens at this point:
+      // Token(0,0 - 0,1:(0:array).(0:value)|"[")
+      // Token(1,0 - 1,1:(0:string).(0:array).(0:value)|""")
+      // Token(1,1 - 1,2:(0:string_content).(0:string).(0:array).(0:value)|"a")
+      // Token(1,2 - 1,3:(0:string).(0:array).(0:value)|""")
+      // Token(1,3 - 1,4:(0:array).(0:value)|",")
+      // Token(2,0 - 2,1:(1:string).(0:array).(0:value)|""")
+      // Token(2,1 - 2,2:(0:string_content).(1:string).(0:array).(0:value)|"b")
+      // Token(2,2 - 2,3:(1:string).(0:array).(0:value)|""")
+      // Token(2,3 - 2,4:(0:array).(0:value)|",")
+      // Token(3,0 - 3,1:(2:string).(0:array).(0:value)|""")
+      // Token(3,1 - 3,1:(2:string).(0:array).(0:value)|)
+      // Token(4,0 - 4,1:(0:array).(0:value)|"]")
+       
+       //List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
+      
+      // With the byte offest bug, we'd instead crash when resolving tokens
+      expect.int(List.length(tokens)).toBe(12);
+  });
   });
 });

--- a/test/ArrayParserTest.re
+++ b/test/ArrayParserTest.re
@@ -133,7 +133,7 @@ describe("ArrayParser", ({describe, _}) => {
       range.startPosition.line == startPosition.line
       && range.startPosition.column == startPosition.column
       && range.endPosition.line == endPosition.line
-      && range.endPosition.column == endPosition.column
+      && range.endPosition.column == endPosition.column;
     };
     test("token positions are preserved when deleting a line", ({expect, _}) => {
       let start = [|"[", "", "]"|];
@@ -149,33 +149,58 @@ describe("ArrayParser", ({describe, _}) => {
       let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), endv);
 
       let node = Tree.getRootNode(tree);
-      let range = Types.Range.create(
-        ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
-        ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
-        (),
-      );
-      prerr_endline ("-----START-------");
+      let range =
+        Types.Range.create(
+          ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
+          ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
+          (),
+        );
+      prerr_endline("-----START-------");
       let getTokenName = Syntax.createArrayTokenNameResolver(endv);
       let tokens = Syntax.getTokens(~getTokenName, ~range, node);
 
       // Validate tokens aren't shifted when deleting a row
       let leftBracket = List.nth(tokens, 0);
-      expect.bool(tokenRangeMatches(
-        ~token=leftBracket,
-        ~range=Types.Range.createi(~startLine=0,~startColumn=0, ~endLine=0, ~endColumn=1, ()),
-        ()
-      )).toBe(true);
+      expect.bool(
+        tokenRangeMatches(
+          ~token=leftBracket,
+          ~range=
+            Types.Range.createi(
+              ~startLine=0,
+              ~startColumn=0,
+              ~endLine=0,
+              ~endColumn=1,
+              (),
+            ),
+          (),
+        ),
+      ).
+        toBe(
+        true,
+      );
 
       expect.string(Syntax.Token.getName(leftBracket)).toEqual("\"[\"");
-      
+
       let rightBracket = List.nth(tokens, 1);
-      expect.bool(tokenRangeMatches(
-        ~token=rightBracket,
-        ~range=Types.Range.createi(~startLine=1,~startColumn=0, ~endLine=1, ~endColumn=1, ()),
-        ()
-      )).toBe(true);
+      expect.bool(
+        tokenRangeMatches(
+          ~token=rightBracket,
+          ~range=
+            Types.Range.createi(
+              ~startLine=1,
+              ~startColumn=0,
+              ~endLine=1,
+              ~endColumn=1,
+              (),
+            ),
+          (),
+        ),
+      ).
+        toBe(
+        true,
+      );
       expect.string(Syntax.Token.getName(rightBracket)).toEqual("\"]\"");
-      List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
+      List.iter(t => prerr_endline(Syntax.Token.show(t)), tokens);
     });
     test("token positions are preserved when adding a line", ({expect, _}) => {
       let start = [|"[", "]"|];
@@ -191,33 +216,59 @@ describe("ArrayParser", ({describe, _}) => {
       let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), endv);
 
       let node = Tree.getRootNode(tree);
-      let getTokenName = (_) => "";
-      let range = Types.Range.create(
-        ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
-        ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
-        (),
-      );
-      prerr_endline ("-----START-------");
+      let getTokenName = _ => "";
+      let range =
+        Types.Range.create(
+          ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
+          ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
+          (),
+        );
+      prerr_endline("-----START-------");
       let tokens = Syntax.getTokens(~getTokenName, ~range, node);
 
       // Validate tokens aren't shifted when deleting a row
       let leftBracket = List.nth(tokens, 0);
-      expect.bool(tokenRangeMatches(
-        ~token=leftBracket,
-        ~range=Types.Range.createi(~startLine=0,~startColumn=0, ~endLine=0, ~endColumn=1, ()),
-        ()
-      )).toBe(true);
-      
+      expect.bool(
+        tokenRangeMatches(
+          ~token=leftBracket,
+          ~range=
+            Types.Range.createi(
+              ~startLine=0,
+              ~startColumn=0,
+              ~endLine=0,
+              ~endColumn=1,
+              (),
+            ),
+          (),
+        ),
+      ).
+        toBe(
+        true,
+      );
+
       let rightBracket = List.nth(tokens, 1);
-      expect.bool(tokenRangeMatches(
-        ~token=rightBracket,
-        ~range=Types.Range.createi(~startLine=2,~startColumn=0, ~endLine=2, ~endColumn=1, ()),
-        ()
-      )).toBe(true);
-      List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
+      expect.bool(
+        tokenRangeMatches(
+          ~token=rightBracket,
+          ~range=
+            Types.Range.createi(
+              ~startLine=2,
+              ~startColumn=0,
+              ~endLine=2,
+              ~endColumn=1,
+              (),
+            ),
+          (),
+        ),
+      ).
+        toBe(
+        true,
+      );
+      List.iter(t => prerr_endline(Syntax.Token.show(t)), tokens);
     });
-    test("token positions are preserved when modifying a line", ({expect, _}) => {
-       let start = [|"[", "", "]"|];
+    test(
+      "token positions are preserved when modifying a line", ({expect, _}) => {
+      let start = [|"[", "", "]"|];
 
       let endv = [|"[", "a", "]"|];
 
@@ -230,33 +281,58 @@ describe("ArrayParser", ({describe, _}) => {
       let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), endv);
 
       let node = Tree.getRootNode(tree);
-      let range = Types.Range.create(
-        ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
-        ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
-        (),
-      );
+      let range =
+        Types.Range.create(
+          ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
+          ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
+          (),
+        );
       let getTokenName = Syntax.createArrayTokenNameResolver(endv);
-      prerr_endline ("-----START-------");
+      prerr_endline("-----START-------");
       let tokens = Syntax.getTokens(~getTokenName, ~range, node);
 
       // Validate tokens aren't shifted when deleting a row
       let leftBracket = List.nth(tokens, 0);
-      expect.bool(tokenRangeMatches(
-        ~token=leftBracket,
-        ~range=Types.Range.createi(~startLine=0,~startColumn=0, ~endLine=0, ~endColumn=1, ()),
-        ()
-      )).toBe(true);
+      expect.bool(
+        tokenRangeMatches(
+          ~token=leftBracket,
+          ~range=
+            Types.Range.createi(
+              ~startLine=0,
+              ~startColumn=0,
+              ~endLine=0,
+              ~endColumn=1,
+              (),
+            ),
+          (),
+        ),
+      ).
+        toBe(
+        true,
+      );
 
       expect.string(Syntax.Token.getName(leftBracket)).toEqual("\"[\"");
-      
+
       let rightBracket = List.nth(tokens, 2);
-      expect.bool(tokenRangeMatches(
-        ~token=rightBracket,
-        ~range=Types.Range.createi(~startLine=2,~startColumn=0, ~endLine=2, ~endColumn=1, ()),
-        ()
-      )).toBe(true);
+      expect.bool(
+        tokenRangeMatches(
+          ~token=rightBracket,
+          ~range=
+            Types.Range.createi(
+              ~startLine=2,
+              ~startColumn=0,
+              ~endLine=2,
+              ~endColumn=1,
+              (),
+            ),
+          (),
+        ),
+      ).
+        toBe(
+        true,
+      );
       expect.string(Syntax.Token.getName(rightBracket)).toEqual("\"]\"");
-      List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
+      List.iter(t => prerr_endline(Syntax.Token.show(t)), tokens);
     });
     test("regression test: multiple delta updates", ({expect, _}) => {
       let jsonParser = Parser.json();
@@ -271,7 +347,7 @@ describe("ArrayParser", ({describe, _}) => {
 
       let delta2 = [|""|];
       let end2 = [|"[", "\"a\",", "\"b\",", "", "]"|];
-      
+
       let delta = ArrayParser.Delta.create(baseline, 3, 3, delta2);
       let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end2);
 
@@ -282,29 +358,30 @@ describe("ArrayParser", ({describe, _}) => {
       let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), end3);
 
       /*let delta4 = [|"\"c"|];
-      let end4 = [|"[", "\"abc\",", "\"c", "]"|];
-      
-      let delta = ArrayParser.Delta.create(baseline, 2, 3, delta4);
-      let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end4);
+        let end4 = [|"[", "\"abc\",", "\"c", "]"|];
 
-      let delta5 = [|"\"\",", "\"d"|];
-      let end5 = [|"[", "\"abc\",", "\"\",", "\"d", "]"|];
+        let delta = ArrayParser.Delta.create(baseline, 2, 3, delta4);
+        let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end4);
 
-      let delta = ArrayParser.Delta.create(baseline, 2, 3, delta5);
-      let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end5);
-      
-      let delta6 = [|"e"|];
-      let end6 = [|"[", "\"abc\",", "\"\",", "\"d", "e", "]"|];
+        let delta5 = [|"\"\",", "\"d"|];
+        let end5 = [|"[", "\"abc\",", "\"\",", "\"d", "]"|];
 
-      let delta = ArrayParser.Delta.create(baseline, 3, 3, delta6);
-      let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), end6); */
-      
+        let delta = ArrayParser.Delta.create(baseline, 2, 3, delta5);
+        let (_, baseline) = ArrayParser.parse(jsonParser, Some(delta), end5);
+
+        let delta6 = [|"e"|];
+        let end6 = [|"[", "\"abc\",", "\"\",", "\"d", "e", "]"|];
+
+        let delta = ArrayParser.Delta.create(baseline, 3, 3, delta6);
+        let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), end6); */
+
       let node = Tree.getRootNode(tree);
-      let rangeLine2 = Types.Range.create(
-        ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
-        ~endPosition=Types.Position.create(~line=6, ~column=0, ()),
-        (),
-      );
+      let rangeLine2 =
+        Types.Range.create(
+          ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
+          ~endPosition=Types.Position.create(~line=6, ~column=0, ()),
+          (),
+        );
 
       let getTokenName = Syntax.createArrayTokenNameResolver(end3);
       let tokens = Syntax.getTokens(~getTokenName, ~range=rangeLine2, node);
@@ -321,11 +398,11 @@ describe("ArrayParser", ({describe, _}) => {
       // Token(3,0 - 3,1:(2:string).(0:array).(0:value)|""")
       // Token(3,1 - 3,1:(2:string).(0:array).(0:value)|)
       // Token(4,0 - 4,1:(0:array).(0:value)|"]")
-       
-       //List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
-      
+
+      //List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
+
       // With the byte offest bug, we'd instead crash when resolving tokens
       expect.int(List.length(tokens)).toBe(12);
-  });
+    });
   });
 });

--- a/test/ArrayParserTest.re
+++ b/test/ArrayParserTest.re
@@ -125,5 +125,138 @@ describe("ArrayParser", ({describe, _}) => {
         "(value (array (string (string_content)) (number) (string (string_content))))",
       );
     });
+
+    let tokenRangeMatches = (~token, ~range: Types.Range.t, ()) => {
+      let startPosition = Syntax.Token.getPosition(token);
+      let endPosition = Syntax.Token.getEndPosition(token);
+
+      range.startPosition.line == startPosition.line
+      && range.startPosition.column == startPosition.column
+      && range.endPosition.line == endPosition.line
+      && range.endPosition.column == endPosition.column
+    };
+    test("token positions are preserved when deleting a line", ({expect, _}) => {
+      let start = [|"[", "", "]"|];
+
+      let endv = [|"[", "]"|];
+
+      let jsonParser = Parser.json();
+      let (_, baseline) = ArrayParser.parse(jsonParser, None, start);
+
+      let update = [||];
+      let delta = ArrayParser.Delta.create(baseline, 1, 2, update);
+
+      let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), endv);
+
+      let node = Tree.getRootNode(tree);
+      let range = Types.Range.create(
+        ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
+        ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
+        (),
+      );
+      prerr_endline ("-----START-------");
+      let getTokenName = Syntax.createArrayTokenNameResolver(endv);
+      let tokens = Syntax.getTokens(~getTokenName, ~range, node);
+
+      // Validate tokens aren't shifted when deleting a row
+      let leftBracket = List.nth(tokens, 0);
+      expect.bool(tokenRangeMatches(
+        ~token=leftBracket,
+        ~range=Types.Range.createi(~startLine=0,~startColumn=0, ~endLine=0, ~endColumn=1, ()),
+        ()
+      )).toBe(true);
+
+      expect.string(Syntax.Token.getName(leftBracket)).toEqual("\"[\"");
+      
+      let rightBracket = List.nth(tokens, 1);
+      expect.bool(tokenRangeMatches(
+        ~token=rightBracket,
+        ~range=Types.Range.createi(~startLine=1,~startColumn=0, ~endLine=1, ~endColumn=1, ()),
+        ()
+      )).toBe(true);
+      expect.string(Syntax.Token.getName(rightBracket)).toEqual("\"]\"");
+      List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
+    });
+    test("token positions are preserved when adding a line", ({expect, _}) => {
+      let start = [|"[", "]"|];
+
+      let endv = [|"[", "", "]"|];
+
+      let jsonParser = Parser.json();
+      let (_, baseline) = ArrayParser.parse(jsonParser, None, start);
+
+      let update = [|""|];
+      let delta = ArrayParser.Delta.create(baseline, 1, 1, update);
+
+      let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), endv);
+
+      let node = Tree.getRootNode(tree);
+      let getTokenName = (_) => "";
+      let range = Types.Range.create(
+        ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
+        ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
+        (),
+      );
+      prerr_endline ("-----START-------");
+      let tokens = Syntax.getTokens(~getTokenName, ~range, node);
+
+      // Validate tokens aren't shifted when deleting a row
+      let leftBracket = List.nth(tokens, 0);
+      expect.bool(tokenRangeMatches(
+        ~token=leftBracket,
+        ~range=Types.Range.createi(~startLine=0,~startColumn=0, ~endLine=0, ~endColumn=1, ()),
+        ()
+      )).toBe(true);
+      
+      let rightBracket = List.nth(tokens, 1);
+      expect.bool(tokenRangeMatches(
+        ~token=rightBracket,
+        ~range=Types.Range.createi(~startLine=2,~startColumn=0, ~endLine=2, ~endColumn=1, ()),
+        ()
+      )).toBe(true);
+      List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
+    });
+    test("token positions are preserved when modifying a line", ({expect, _}) => {
+       let start = [|"[", "", "]"|];
+
+      let endv = [|"[", "a", "]"|];
+
+      let jsonParser = Parser.json();
+      let (_, baseline) = ArrayParser.parse(jsonParser, None, start);
+
+      let update = [|"a"|];
+      let delta = ArrayParser.Delta.create(baseline, 1, 2, update);
+
+      let (tree, _) = ArrayParser.parse(jsonParser, Some(delta), endv);
+
+      let node = Tree.getRootNode(tree);
+      let range = Types.Range.create(
+        ~startPosition=Types.Position.create(~line=0, ~column=0, ()),
+        ~endPosition=Types.Position.create(~line=3, ~column=0, ()),
+        (),
+      );
+      let getTokenName = Syntax.createArrayTokenNameResolver(endv);
+      prerr_endline ("-----START-------");
+      let tokens = Syntax.getTokens(~getTokenName, ~range, node);
+
+      // Validate tokens aren't shifted when deleting a row
+      let leftBracket = List.nth(tokens, 0);
+      expect.bool(tokenRangeMatches(
+        ~token=leftBracket,
+        ~range=Types.Range.createi(~startLine=0,~startColumn=0, ~endLine=0, ~endColumn=1, ()),
+        ()
+      )).toBe(true);
+
+      expect.string(Syntax.Token.getName(leftBracket)).toEqual("\"[\"");
+      
+      let rightBracket = List.nth(tokens, 2);
+      expect.bool(tokenRangeMatches(
+        ~token=rightBracket,
+        ~range=Types.Range.createi(~startLine=2,~startColumn=0, ~endLine=2, ~endColumn=1, ()),
+        ()
+      )).toBe(true);
+      expect.string(Syntax.Token.getName(rightBracket)).toEqual("\"]\"");
+      List.iter((t) => prerr_endline (Syntax.Token.show(t)), tokens);
+    });
   });
 });


### PR DESCRIPTION
In hooking up the incremental updates with Onivim 2, there was a bug in which multiple delta updates would cause the syntax tree to become corrupted.

The root cause was that we track byte offsets for each line - but we only update them when the parser calls into the `f` callback. In incremental cases, it's not guaranteed this will happen for each line, so we end up with some lines incorrectly have a `0` byte offset.

The brute-force fix for this is just to recalculate the byte offsets. In profiling the function, this isn't the bottleneck (the main issue is the back-and-forth we have accessing the string array!).